### PR TITLE
Use cookies for auth and stream listener stats

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -5,4 +5,7 @@ MONGO_URI=
 PORT=
 PROXY_LIST_URL=url to return a list of proxies for yt-dlp. the response must be proxies separated by /r/n
 INITIAL_TRACK_IDS=comma separated list of spotify track ids to seed the database with
+CORS_ORIGIN=
+JWT_SECRET=
+ENVIRONMENT=dev or prod
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.7.3",
         "bcrypt": "^5.1.1",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "email-validator": "^2.0.4",
@@ -831,6 +832,28 @@
     },
     "node_modules/cookie": {
       "version": "0.6.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "axios": "^1.7.3",
     "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "email-validator": "^2.0.4",

--- a/src/client/AccountClient.js
+++ b/src/client/AccountClient.js
@@ -118,7 +118,27 @@ class AccountClient extends ClientService {
 
     const token = jwt.sign({ handle }, process.env.JWT_SECRET);
     console.log("user logged in with handle:", handle);
-    res.json({ token });
+    res.cookie("token", token, {
+      httpOnly: true,
+      secure: process.env.ENVIRONMENT === "prod",
+      sameSite: "none",
+    });
+    res.json({});
+  }
+
+  async logout(req, res) {
+    const authHandle = this.authenticateStrict(req, res);
+    if (!authHandle) {
+      return;
+    }
+
+    console.log("Logging out user with handle:", authHandle);
+    res.clearCookie("token", {
+      httpOnly: true,
+      secure: process.env.ENVIRONMENT === "prod",
+      sameSite: "none",
+    });
+    res.json({});
   }
 
   async getPublicProfile(req, res) {

--- a/src/client/ClientService.js
+++ b/src/client/ClientService.js
@@ -11,7 +11,7 @@ class ClientService extends EventEmitter {
   }
 
   authenticateStrict(req, res) {
-    const token = req.headers.authorization?.split(" ")[1];
+    const token = req.cookies?.token;
     if (!token) {
       res.status(401).json({ message: "Unauthorized" });
       return;
@@ -27,7 +27,7 @@ class ClientService extends EventEmitter {
   }
 
   authenticateLoose(req) {
-    const token = req.headers.authorization?.split(" ")[1];
+    const token = req.cookies?.token;
     if (!token) return null;
 
     try {

--- a/src/client/StreamClient.js
+++ b/src/client/StreamClient.js
@@ -32,7 +32,7 @@ class StreamClient extends ClientService {
     this.emit("clientConnected");
     res.on("close", () => {
       ClientService.removeClient(res, handle);
-      console.log("disconnected: ", ClientService._listeners);
+      this.emit("clientDisconnected");
     });
   }
 

--- a/src/client/StreamClient.js
+++ b/src/client/StreamClient.js
@@ -1,21 +1,23 @@
-import AccountModelService from "../services/db/AccountModelService.js";
 import ClientService from "./ClientService.js";
 
 class StreamClient extends ClientService {
-  async addClientToStream(req, res) {
-    // TODO: implement a way to use tokens for existing users
-    const handle = req.query.handle;
-    // only allow handles that exist in the db or start with "anon" followed by 20 chars
-    if (
-      !handle ||
-      !(
-        (await AccountModelService.isHandleTaken(handle)) ||
-        (handle.startsWith("anon") && handle.length === 24)
-      )
-    ) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
+  _getStreamId(req, res) {
+    let handle = this.authenticateLoose(req);
+    if (!handle) {
+      handle =
+        req.cookies["anonymous-stream-id"] ||
+        `anonymous-listener-${Math.random().toString(36)}`;
+      res.cookie("anonymous-stream-id", handle, {
+        httpOnly: true,
+        sameSite: "strict",
+        secure: process.env.ENVIRONMENT === "prod",
+      });
     }
+    return handle;
+  }
+
+  async addClientToStream(req, res) {
+    let handle = this._getStreamId(req, res);
 
     res.writeHead(200, {
       "Content-Type": "audio/mpeg",
@@ -28,21 +30,19 @@ class StreamClient extends ClientService {
 
     ClientService.addClient(res, handle);
     this.emit("clientConnected");
-
     res.on("close", () => {
       ClientService.removeClient(res, handle);
-      this.emit("clientDisconnected");
+      console.log("disconnected: ", ClientService._listeners);
     });
   }
 
   getListeners(req, res) {
-    // listener starts with anon followed by 20 numbers is an anonymous listener.
     const listeners = Array.from(ClientService._listeners);
     const loggedInListeners = listeners.filter(
-      (listener) => listener.length <= 20,
+      (listener) => !listener.startsWith("anonymous-listener"),
     );
-    const anonListeners = listeners.filter(
-      (listener) => listener.startsWith("anon") && listener.length === 24,
+    const anonListeners = listeners.filter((listener) =>
+      listener.startsWith("anonymous-listener"),
     );
     res.json({
       count: {
@@ -52,31 +52,6 @@ class StreamClient extends ClientService {
       },
       list: loggedInListeners,
     });
-  }
-
-  tuneOut(req, res) {
-    // This will remove the listener even if they are still listening in another tab.
-    // TODO: find a way to work around this for more accurate listener count
-    const handle = req.query.handle;
-    const authHandle = this.authenticateLoose(req);
-
-    // Only allow the listener to tune out if they are the same listener
-    if (authHandle && authHandle !== handle) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    // Only allow anonymous listeners to tune themselves out. (It is unlikely an anonymous listener will be able to tune out another anonymous listener)
-    if (
-      !authHandle &&
-      (!handle || handle.length !== 24 || !handle.startsWith("anon"))
-    ) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    ClientService.removeClient(null, handle);
-    res.json({ success: true });
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,17 @@ import SongController from "./controllers/songController.js";
 import DatabaseService from "./services/db/DatabaseService.js";
 import RequestModelService from "./services/db/RequestModelService.js";
 import AccountModelService from "./services/db/AccountModelService.js";
+import cookieParser from "cookie-parser";
 
 const corsOptions = {
   origin: process.env.CORS_ORIGIN || "*",
   optionsSuccessStatus: 200,
+  credentials: true,
 };
 
 const app = express();
 app.use(cors(corsOptions));
+app.use(cookieParser());
 app.use(express.json());
 // eslint-disable-next-line no-unused-vars
 app.use((err, req, res, next) => {

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -8,7 +8,6 @@ const router = Router();
 // Stream Routes
 router.get("/stream", (req, res) => StreamClient.addClientToStream(req, res));
 router.get("/listeners", (req, res) => StreamClient.getListeners(req, res));
-router.get("/tuneout", (req, res) => StreamClient.tuneOut(req, res));
 
 // Song Routes
 router.get("/song/current", (req, res) =>
@@ -23,6 +22,7 @@ router.post("/song/submit", (req, res) =>
 // Account Routes
 router.post("/register", (req, res) => AccountClient.register(req, res));
 router.post("/login", (req, res) => AccountClient.login(req, res));
+router.post("/logout", (req, res) => AccountClient.logout(req, res));
 router.get("/handle", (req, res) =>
   AccountClient.getHandleAndPictureFromToken(req, res),
 );


### PR DESCRIPTION
Fixes #11 

less overhead in client, more accurate listener count in client. removes need for tuneout endpoint